### PR TITLE
Use cp.execSync on winblows 10, otherwise it hangs forever

### DIFF
--- a/tasks/po2mo.js
+++ b/tasks/po2mo.js
@@ -9,7 +9,7 @@
 'use strict';
 
 var exec = require('sync-exec');
-
+const cp = require("child_process");
 module.exports = function(grunt) {
 
   grunt.registerMultiTask('po2mo', 'Compile .po files into binary .mo files with msgfmt.', function() {
@@ -30,8 +30,17 @@ module.exports = function(grunt) {
       var command = 'msgfmt -o ' + dest + ' ' + src;
 
       grunt.verbose.writeln('Executing: ' + command);
-      var result = exec(command);
-      grunt.verbose.writeln('Executed with status: ' + result.status);
+      // it is possible that this should be a config
+      // choice in case win64 is being tarded
+      if ( process.platform == 'win32' ) {
+        var stdout = cp.execSync(command);
+        grunt.verbose.writeln('Executed with stdout of: ' + stdout);
+        var result = {status: 0};
+      } else {
+        var result = exec(command);
+        grunt.verbose.writeln('Executed with status: ' + result.status);
+      }
+      
 
       if (result.status !== 0) {
         grunt.log.error(result.stderr);

--- a/tasks/po2mo.js
+++ b/tasks/po2mo.js
@@ -9,7 +9,7 @@
 'use strict';
 
 var exec = require('sync-exec');
-const cp = require("child_process");
+var cp = require("child_process");
 module.exports = function(grunt) {
 
   grunt.registerMultiTask('po2mo', 'Compile .po files into binary .mo files with msgfmt.', function() {


### PR DESCRIPTION
So on my windows 10vx64 using exec hangs forever, even though straight running the command works fine. Using cp.execSync fixes the problem, but is probably not necessary for anyone not using winblows.

